### PR TITLE
mt76: mt76s: Read clear those counter reported from Tx done interrupt

### DIFF
--- a/drivers/net/wireless/mediatek/mt76/mt76s.h
+++ b/drivers/net/wireless/mediatek/mt76/mt76s.h
@@ -94,6 +94,8 @@
 #define MCR_WTQCR5			0x0144
 #define MCR_WTQCR6			0x0148
 #define MCR_WTQCR7			0x014C
+#define MCR_WTQCR(x)                   (0x130 + 4 * (x))
+
 #define MCR_SWPCDBGR			0x0154
 
 #endif

--- a/drivers/net/wireless/mediatek/mt76/sdio.c
+++ b/drivers/net/wireless/mediatek/mt76/sdio.c
@@ -708,6 +708,7 @@ static void mt76s_sdio_irq(struct sdio_func *func)
 {
 	struct mt76_dev *dev = sdio_get_drvdata(func);
 	u32 intr;
+	int i;
 
 	/* disable interrupt */
 	sdio_writel(func, WHLPCR_INT_EN_CLR, MCR_WHLPCR, 0);
@@ -734,8 +735,12 @@ static void mt76s_sdio_irq(struct sdio_func *func)
 		tasklet_schedule(&dev->sdio.rx_tasklet);
 	}
 
-	if (intr & WHIER_TX_DONE_INT_EN)
+	if (intr & WHIER_TX_DONE_INT_EN) {
+		for (i = 0 ; i < 8 ; i++)
+			sdio_readl(func, MCR_WTQCR(i), 0);
+
 		tasklet_schedule(&dev->tx_tasklet);
+	}
 out:
 	/* enable interrupt */
 	sdio_writel(func, WHLPCR_INT_EN_SET, MCR_WHLPCR, 0);


### PR DESCRIPTION
Read clear those counters that would be updated when PSE/PLE return page to
avoid tx done triggered again.

Those counters are required to be maintained further to control available
PSE/PLE pages already sent by the host driver.

Co-developed-by: Sean Wang <sean.wang@mediatek.com>
Signed-off-by: Sean Wang <sean.wang@mediatek.com>