### PR TITLE
mt76: mt7921: mt7921_stop should put device in fw_own state

### DIFF
--- a/drivers/net/wireless/mediatek/mt76/mt76_connac_mac.c
+++ b/drivers/net/wireless/mediatek/mt76/mt76_connac_mac.c
@@ -37,7 +37,7 @@ void mt76_connac_power_save_sched(struct mt76_phy *phy,
 	if (!mt76_is_mmio(dev))
 		return;
 
-	if (!pm->enable || !test_bit(MT76_STATE_RUNNING, &phy->state))
+	if (!pm->enable)
 		return;
 
 	pm->last_activity = jiffies;


### PR DESCRIPTION
mt7921_stop should put device in fw_own state to reduce
power consumption.

Signed-off-by: Sean Wang <sean.wang@mediatek.com>